### PR TITLE
TINY-12677: Build before publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2.3.1 - 2025-08-11
+
+### Fixed
+- JS files were missing in the NPM package. # TINY-12257
+
 ## 2.3.0 - 2025-07-31
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 2.3.1 - 2025-08-11
 
 ### Fixed
-- JS files were missing in the NPM package. # TINY-12257
+- JS files were missing in the NPM package. #TINY-12257
 
 ## 2.3.0 - 2025-07-31
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,4 +9,8 @@ mixedBeehiveFlow(
     [ browser: 'firefox', provider: 'aws', buckets: 1 ],
     [ browser: 'safari', provider: 'lambdatest', buckets: 1 ]
   ],
+  preparePublish: {
+    yarnInstall()
+    sh "yarn build"
+  }
 )

--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
   "dependencies": {
     "@tinymce/miniature": "^6.0.0"
   },
-  "version": "2.3.1-rc",
+  "version": "2.3.1",
   "name": "@tinymce/tinymce-webcomponent"
 }


### PR DESCRIPTION
Related ticket: TINY-12677

**Description of changes**:
- Added the missing pre-build step that builds the project before bundling