### PR TITLE
Fix disconnected editor not destroyed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Editor initialization failure error handling. #INT-3366
+- Disconnected Editor not destroyed.
 
 ## 2.3.1 - 2025-08-11
 

--- a/src/main/ts/component/Editor.ts
+++ b/src/main/ts/component/Editor.ts
@@ -339,7 +339,7 @@ class TinyMceEditor extends HTMLElement {
     this._mutationObserver.disconnect();
     this._updateForm();
     if (this._editor) {
-        this._getTinymce().remove(this._editor)
+      this._getTinymce().remove(this._editor);
     }
   }
 

--- a/src/main/ts/component/Editor.ts
+++ b/src/main/ts/component/Editor.ts
@@ -338,6 +338,9 @@ class TinyMceEditor extends HTMLElement {
   disconnectedCallback(): void {
     this._mutationObserver.disconnect();
     this._updateForm();
+    if (this._editor) {
+        this._getTinymce().remove(this._editor)
+    }
   }
 
   get value(): string | null {

--- a/src/test/ts/browser/LoadTest.ts
+++ b/src/test/ts/browser/LoadTest.ts
@@ -44,7 +44,7 @@ UnitTest.asynctest('LoadTest', (success, failure) => {
     }),
     Step.sync(() => removeTinymceElement()),
     Step.sync(() => {
-      Assertions.assertEq('Global TinyMCE not destroyed', true, Global.tinymce.get('example_id') === null);
+      Assertions.assertEq('The editor instance is removed', true, Global.tinymce.get('example_id') === null);
     })
   ], success, failure);
 });

--- a/src/test/ts/browser/LoadTest.ts
+++ b/src/test/ts/browser/LoadTest.ts
@@ -33,13 +33,18 @@ UnitTest.asynctest('LoadTest', (success, failure) => {
     }),
     Step.sync(() => makeTinymceElement({
       'setup': 'customElementTinymceSetup',
-      'on-init': 'customElementTinymceInit'
+      'on-init': 'customElementTinymceInit',
+      'id': 'example_id'
     }, '<p>Hello world</p>')),
     Waiter.sTryUntilPredicate('Waiting for editor setup', () => seenSetup),
     Waiter.sTryUntilPredicate('Waiting for editor init', () => seenInit),
     Step.sync(() => {
       Assertions.assertHtmlStructure('', '<p>Hello world</p>', editorInstance.getContent() as string);
+      Assertions.assertEq('Global TinyMCE is not set', true, Global.tinymce.get('example_id') !== null);
     }),
-    Step.sync(() => removeTinymceElement())
+    Step.sync(() => removeTinymceElement()),
+    Step.sync(() => {
+      Assertions.assertEq('Global TinyMCE not destroyed', true, Global.tinymce.get('example_id') === null);
+    })
   ], success, failure);
 });

--- a/src/test/ts/browser/LoadTest.ts
+++ b/src/test/ts/browser/LoadTest.ts
@@ -40,7 +40,7 @@ UnitTest.asynctest('LoadTest', (success, failure) => {
     Waiter.sTryUntilPredicate('Waiting for editor init', () => seenInit),
     Step.sync(() => {
       Assertions.assertHtmlStructure('', '<p>Hello world</p>', editorInstance.getContent() as string);
-      Assertions.assertEq('Global TinyMCE is not set', true, Global.tinymce.get('example_id') !== null);
+      Assertions.assertEq('An editor instance is registered', true, Global.tinymce.get('example_id') !== null);
     }),
     Step.sync(() => removeTinymceElement()),
     Step.sync(() => {


### PR DESCRIPTION
My App has a feature to remove and add tinymce same editor again (see video).
But second time adding not working since in global `tinyMCE` object previous editor didn't remove properly, for tinyMCE it was already initialized
[Screencast_20251209_180118.webm](https://github.com/user-attachments/assets/106d7a62-f38d-4d64-9105-cf005b50718f)

Please make a new release once merged
